### PR TITLE
Completa validaciones del flujo de vacaciones

### DIFF
--- a/lib/Controller/AusenciasController.php
+++ b/lib/Controller/AusenciasController.php
@@ -319,7 +319,17 @@ class AusenciasController extends BaseController {
                             $this->groupManager->isInGroup($uid, 'recursos_humanos');
 
             if ($isPrivileged) {
-                $user =  $this->userManager->get($this->request->getParam('id_usuario'));
+                $targetUserId = (string) $this->request->getParam('id_usuario');
+                if ($targetUserId === '') {
+                    return new DataResponse(['success' => false, 'message' => 'Debe seleccionar un empleado para registrar la ausencia.']);
+                }
+
+                $targetUser = $this->userManager->get($targetUserId);
+                if ($targetUser === null) {
+                    return new DataResponse(['success' => false, 'message' => 'No se encontró el usuario seleccionado para registrar la ausencia.']);
+                }
+
+                $user = $targetUser;
             }
 
             $gestor = $this->configuracionesMapper->GetGestor()[0]['Data'] ?? null;
@@ -372,8 +382,17 @@ class AusenciasController extends BaseController {
             $id_empleado = $this->empleadosMapper->GetMyEmployeeInfo($user->getUID());
             $empleado_ausencias = $this->ausenciasMapper->GetAusenciasByUser($id_empleado[0]['Id_empleados']);
             
-            $fechaDeObj = DateTime::createFromFormat('d/m/Y', $this->request->getParam('fecha_de'));
-            $fechaHastaObj = DateTime::createFromFormat('d/m/Y', $this->request->getParam('fecha_hasta'));
+            $fechaDeObj = DateTime::createFromFormat('d/m/Y', (string) $this->request->getParam('fecha_de'));
+            $fechaHastaObj = DateTime::createFromFormat('d/m/Y', (string) $this->request->getParam('fecha_hasta'));
+
+            if ($fechaDeObj === false || $fechaHastaObj === false) {
+                return new DataResponse(['success' => false, 'message' => 'Formato de fecha inválido. Utiliza DD/MM/AAAA.']);
+            }
+
+            if ($fechaDeObj > $fechaHastaObj) {
+                return new DataResponse(['success' => false, 'message' => 'La fecha inicial no puede ser posterior a la fecha final.']);
+            }
+
             $hoy = new \DateTime();
 
             // Normalizamos horas
@@ -394,8 +413,8 @@ class AusenciasController extends BaseController {
                 $this->ausenciasMapper->updateAusenciasEmpleado($empleado_ausencias[0]['id_ausencias'], $dias_disponibles);
             }
             
-            $fecha_de = DateTime::createFromFormat('d/m/Y', $this->request->getParam('fecha_de'))->format('Y-m-d');
-            $fecha_hasta = DateTime::createFromFormat('d/m/Y', $this->request->getParam('fecha_hasta'))->format('Y-m-d');
+            $fecha_de = $fechaDeObj->format('Y-m-d');
+            $fecha_hasta = $fechaHastaObj->format('Y-m-d');
 
             // Registro en el historial de ausencias 
             $idHistorialAusencia = $this->historialausenciasMapper->EnviarAusencia((int) $id_tipo_ausencia, $empleado_ausencias[0]['id_ausencias'], $fecha_de, $fecha_hasta, (int) $prima_vacacional, $notas, $empleado_ausencias[0]['id_aniversario']);

--- a/src/views/components/TiempoLibre/Modal/NuevaSolicitud.vue
+++ b/src/views/components/TiempoLibre/Modal/NuevaSolicitud.vue
@@ -85,7 +85,7 @@
 									:text="t('empleados', 'You are registering an absence in admin mode. Notifications and automatic messages will remain active, and the corresponding days will be deducted from the selected employee.')" />
 								<br>
 							</div>
-							<div v-else>
+							<div>
 								<table class="top">
 									<caption>{{ t('empleados', 'PERIOD DATA') }}</caption>
 									<tbody>
@@ -206,7 +206,11 @@
 						</div>
 
 						<div v-else class="top">
-							<NcButton variant="secondary" wide @click="EnviarAusencia()">
+							<NcButton
+								variant="secondary"
+								wide
+								:disabled="!canSubmit"
+								@click="EnviarAusencia()">
 								<template #icon>
 									<Airplane :size="20" />
 								</template>
@@ -255,7 +259,7 @@ export default {
 
 	props: {
 		diasSolicitados: { type: Number, required: true },
-		diasDisponibles: { type: String, required: true },
+		diasDisponibles: { type: [String, Number], required: true },
 		date: {
 			type: Object,
 			required: true,
@@ -290,8 +294,30 @@ export default {
 		}
 	},
 
+	computed: {
+		canSubmit() {
+			if (!this.AusenciaSeleccionada || !this.date?.start || !this.date?.end) {
+				return false
+			}
+
+			if (this.admin && !this.employees_list?.user) {
+				return false
+			}
+
+			if (this.AusenciaSeleccionada.solicitar_archivo && this.selectedFiles.length === 0) {
+				return false
+			}
+
+			if (this.AusenciaSeleccionada.solicitar_prima_vacacional === 1 && this.diasSolicitados > this.TotalDias) {
+				return false
+			}
+
+			return true
+		},
+	},
+
 	mounted() {
-		this.TotalDias = parseInt(this.diasDisponibles, 10)
+		this.TotalDias = Number(this.diasDisponibles) || 0
 		this.RestanteDias = this.TotalDias - this.diasSolicitados
 		this.GetTipoAusencias()
 	},
@@ -331,16 +357,30 @@ export default {
 			this.selectedFiles = Array.from(files)
 		},
 
+		formatDateForApi(date) {
+			const day = String(date.getDate()).padStart(2, '0')
+			const month = String(date.getMonth() + 1).padStart(2, '0')
+			const year = date.getFullYear()
+			return `${day}/${month}/${year}`
+		},
+
 		async EnviarAusencia() {
+			if (!this.canSubmit) {
+				showError(t('empleados', 'Please complete all required fields before submitting the request.'))
+				return
+			}
+
 			this.loading = true
 			try {
 				const formData = new FormData()
-				formData.append('id_usuario', this.employees_list.user)
+				if (this.admin && this.employees_list?.user) {
+					formData.append('id_usuario', this.employees_list.user)
+				}
 				formData.append('id_tipo_ausencia', this.AusenciaSeleccionada.id)
 				formData.append('dias_solicitados', this.diasSolicitados)
-				formData.append('fecha_de', this.date.start.toLocaleDateString())
-				formData.append('fecha_hasta', this.date.end ? this.date.end.toLocaleDateString() : '')
-				formData.append('prima_vacacional', this.SolicitarPrima)
+				formData.append('fecha_de', this.formatDateForApi(this.date.start))
+				formData.append('fecha_hasta', this.date.end ? this.formatDateForApi(this.date.end) : '')
+				formData.append('prima_vacacional', this.SolicitarPrima ? '1' : '0')
 				formData.append('notas', this.comentarios || '')
 
 				for (let i = 0; i < this.selectedFiles.length; i++) {


### PR DESCRIPTION
### Motivation
- Evitar envíos incompletos o con fechas inválidas desde el formulario de vacaciones y endurecer validaciones en el backend para casos administrativos.

### Description
- Frontend: se añadió `canSubmit` y se deshabilita el botón `Submit` hasta que haya tipo de ausencia, rango de fechas completo, empleado seleccionado en modo admin, archivos cuando son obligatorios y días disponibles suficientes; además `diasDisponibles` acepta `string|number`, se agregó `formatDateForApi()` y `prima_vacacional` se envía como `"1"/"0"` (file: `src/views/components/TiempoLibre/Modal/NuevaSolicitud.vue`).
- Frontend: el `id_usuario` solo se añade al `FormData` cuando aplica (modo administrador) para evitar payloads incorrectos (file: `src/views/components/TiempoLibre/Modal/NuevaSolicitud.vue`).
- Backend: en `EnviarAusencia` se valida que el admin/RH seleccione un usuario objetivo válido y se retorna un error claro si falta o no existe; además se parsean las fechas con `DateTime::createFromFormat('d/m/Y', ...)`, se valida el formato y que `fecha_de` no sea posterior a `fecha_hasta`, y se reutilizan las fechas parseadas para persistir en `Y-m-d` (file: `lib/Controller/AusenciasController.php`).
- Cambios menores de robustez: normalización de tipos y mensajes de error para evitar errores en tiempo de ejecución y inconsistencias en formato de fecha.

### Testing
- Ejecutado `npx eslint src/views/components/TiempoLibre/Modal/NuevaSolicitud.vue` y pasó sin errores tras ajustes (succeeded).
- Ejecutado `php -l lib/Controller/AusenciasController.php` y no se detectaron errores de sintaxis (succeeded).
- Intenté una captura con Playwright contra `http://localhost:8080` pero falló porque el servidor local no respondió en este entorno (`ERR_EMPTY_RESPONSE`) (failed - environment/network limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b81a1e5cc8326b251e0de820b02dd)